### PR TITLE
Remove DARDUINO_USB_CDC_ON_BOOT from seeed_xiao_esp32c3

### DIFF
--- a/boards/seeed-xiao-esp32c3.yaml
+++ b/boards/seeed-xiao-esp32c3.yaml
@@ -1,8 +1,4 @@
 esp32:
   board: seeed_xiao_esp32c3
-esphome:
-  platformio_options:
-    board_build.extra_flags:
-      - "-DARDUINO_USB_CDC_ON_BOOT=0"
 logger:
   baud_rate: 0


### PR DESCRIPTION
```
<command-line>: warning: "ARDUINO_USB_CDC_ON_BOOT" redefined
<command-line>: note: this is the location of the previous definition
```